### PR TITLE
Add test translation workflow

### DIFF
--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,0 +1,25 @@
+name: 'Test Translation Action'
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited]
+  pull_request_target:
+    types: [opened, edited]
+  pull_request_review_comment:
+    types: [created, edited]
+
+jobs:
+  translate:
+    permissions:
+      issues: write
+      discussions: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: lizheming/github-translate-action@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          APPEND_TRANSLATION: true

--- a/.github/workflows/translate-test.yml
+++ b/.github/workflows/translate-test.yml
@@ -1,8 +1,12 @@
-name: 'Test Translation Action'
+name: 'Translate GitHub content into English'
 on:
   issues:
     types: [opened, edited]
   issue_comment:
+    types: [created, edited]
+  discussion:
+    types: [created, edited]
+  discussion_comment:
     types: [created, edited]
   pull_request_target:
     types: [opened, edited]


### PR DESCRIPTION
我已经查看了这个翻译动作的实现，看起来很有用。以下是几点建议：

1. 我们应该考虑添加一个选项，允许用户选择目标语言
2. 可能需要为翻译服务添加错误处理机制
3. 应该添加一些日志记录，以便于调试

这个功能对于提高Higress在国际社区的可见度将非常有价值。当非英语用户提交问题或评论时，这个自动翻译功能可以确保所有维护者都能理解内容，无论他们使用什么语言。